### PR TITLE
fixed a link and spelling of "Hangfire"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sgbj.Cron.CronTimer
 Provides a cron timer similar to [`System.Threading.PeriodicTimer`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.periodictimer?view=net-6.0) that enables waiting asynchronously for timer ticks.
 
-Available on [NuGet](https://www.nuget.org/packages/Dukpt/).
+Available on [NuGet](https://www.nuget.org/packages/Sgbj.Cron.CronTimer).
 
 ## Usage
 
@@ -44,5 +44,5 @@ using var timer = new CronTimer(CronExpression.Parse("*/30 * * * * *", CronForma
 
 ## Resources
 
-* [Hanfire/Cronos](https://github.com/HangfireIO/Cronos) - Library for working with cron expressions.
+* [Hangfire/Cronos](https://github.com/HangfireIO/Cronos) - Library for working with cron expressions.
 * [Crontab.guru](https://crontab.guru/) - The cron schedule expression editor.


### PR DESCRIPTION
Hey, I wanted to update your NuGet package link, and I fixed a minor typo in the readme.