### PR TITLE
fix null related issues in Dispose method

### DIFF
--- a/CronTimer/CronTimer.cs
+++ b/CronTimer/CronTimer.cs
@@ -18,8 +18,8 @@ public sealed class CronTimer : IDisposable
     private readonly CronExpression _expression;
     private readonly TimeZoneInfo _zone;
     private bool _canceled;
-    private readonly Timer? _timer;
-    private readonly State? _state;
+    private readonly Timer _timer;
+    private readonly State _state;
 
     /// <summary>Initializes the timer with the given cron expression and <see cref="TimeZoneInfo.Utc"/> zone.</summary>
     /// <param name="expression">The cron expression to use.</param>

--- a/CronTimer/CronTimer.cs
+++ b/CronTimer/CronTimer.cs
@@ -18,8 +18,8 @@ public sealed class CronTimer : IDisposable
     private readonly CronExpression _expression;
     private readonly TimeZoneInfo _zone;
     private bool _canceled;
-    private readonly Timer _timer;
-    private readonly State _state;
+    private readonly Timer? _timer;
+    private readonly State? _state;
 
     /// <summary>Initializes the timer with the given cron expression and <see cref="TimeZoneInfo.Utc"/> zone.</summary>
     /// <param name="expression">The cron expression to use.</param>
@@ -97,16 +97,19 @@ public sealed class CronTimer : IDisposable
     {
         GC.SuppressFinalize(this);
 
-        lock (_timer)
+        if (_timer != null)
         {
-            if (!_canceled)
+            lock (_timer)
             {
-                _canceled = true;
-                _timer.Dispose();
+                if (!_canceled)
+                {
+                    _canceled = true;
+                    _timer.Dispose();
+                }
             }
         }
 
-        _state.Signal(stopping: true);
+        _state?.Signal(stopping: true);
     }
 
     ~CronTimer() => Dispose();


### PR DESCRIPTION
Issue described in https://github.com/sgbj/crontimer/issues/2

I did not study the code much, there are still some problems with the way you dispose, but these changes fixed the issue for me and I saw no side effects. 

First problem was that when `lock (_timer)` in Dispose() was called, _timer was null. Later the same thing happened in Dispose() for `_state.Signal(stopping: true);`, this time _state was null.